### PR TITLE
Switch to Replicate for AI generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@
 
 ## Features
 
-- Uses OpenAI's GPT-4 to generate the text and image prompt for the meme.
-- Automatically sends image prompt request to an AI image generator of choice, then combines the text and image
+- Uses models hosted on [Replicate](https://replicate.com) to generate the meme text and images.
+- Combines the generated text and image into a final meme
 - Allows customization of the meme generation process through various settings.
 - Generates memes with a user-provided subject or concept, or you can let the AI decide.
 - Logs meme generation details for future reference.
@@ -15,7 +15,7 @@
 ## Usage
 
 1. For Python Version Only: Clone the repository & Install the necessary packages.
-2. Obtain at least an OpenAI API key, but it is recommended to also use APIs from Clipdrop or Stability AI (DreamStudio) for the image generation stage.
+2. Obtain a Replicate API token from <https://replicate.com/account>.
 3. Edit the settings variables in the settings.ini file.
 4. Run the script and enter a meme subject or concept when prompted (optional).
 
@@ -23,8 +23,8 @@
 
 Various settings for the meme generation process can be customized:
 
-- OpenAI API settings: Choose the text model and temperature for generating the meme text and image prompt.
-- Image platform settings: Choose the platform for generating the meme image. Options include OpenAI's DALLE2, StabilityAI's DreamStudio, and ClipDrop.
+- Replicate model settings: Choose the text model and temperature for generating the meme text and image prompt.
+- Image model settings: Choose the model on Replicate to generate the meme image.
 - Basic Meme Instructions: You can tell the AI about the general style or qualities to apply to all memes, such as using dark humor, surreal humor, wholesome, etc. 
 - Special Image Instructions: You can tell the AI how to generate the image itself (more specifically,  how to write the image prompt). You can specify a style such as being a photograph, drawing, etc, or something more specific such as always using cats in the pictures.
 
@@ -44,12 +44,8 @@ Image Generation Platform: clipdrop
 ## Optional Arguments
 ### You can also pass options into the program via command-line arguments whether using the python version or exe version.
 
-#### • API Key Arguments: Not necessary if the keys are already in api_keys.ini
-`--openaikey`: OpenAI API key.
-
-`--clipdropkey`: ClipDrop API key.
-
-`--stabilitykey`: Stability AI API key.
+#### • API Key Arguments: Not necessary if the key is already in api_keys.ini
+`--replicatekey`: Replicate API token.
 
 #### • Basic Meme Arguments
 
@@ -59,7 +55,7 @@ Image Generation Platform: clipdrop
 
 #### • Advanced Meme Settings Arguments
 
-`--imageplatform`: The image platform to use. If using arguments and not specified, the default is 'clipdrop'. Possible options: 'openai', 'stability', 'clipdrop'.
+`--imagemodel`: The image model to use on Replicate. If not specified, the default is 'stability-ai/sdxl'.
 
 `--temperature`: The temperature to use for the chat bot. If using arguments and not specified, the default is 1.0.
 

--- a/Requirements.txt
+++ b/Requirements.txt
@@ -1,4 +1,3 @@
-openai>=1.6.1
-stability-sdk>=0.8.5
+replicate>=1.0.0
 pillow>=10.1.0
 requests>=2.31.0

--- a/assets/api_keys_empty.ini
+++ b/assets/api_keys_empty.ini
@@ -1,26 +1,8 @@
-# --------------------------- API KEYS INSTRUCTIONS ---------------------------
-# • Paste your API keys for the following services below.
-#     - Note: An OpenAI key is always required, because this script uses chatGPT to generate the meme text and image prompts.
-#
-# • ClipDrop and StabilityAI are both optional, but they will create MUCH better images than OpenAI's DALLE-2.
-#     - Note: If using ClipDrop or StabilityAI, remember to change the 'image_platform' setting in the script.
-#
-# • Here is where you can obtain each services' API Key for your accounts:
-#     - OpenAI: https://beta.openai.com/account/api-keys
-#     - StabilityAI (DreamStudio): https://dreamstudio.ai/account
-#     - ClipDrop: https://clipdrop.co/apis/account
-#
-# • More notes about the platforms:
-#     - OpenAI owns ChatGPT and is what this script uses to generate the image prompts and meme text. It also has DALLE2 as an image generator but it's an outdated model.
-#     - StabilityAI actually owns two different platforms: ClipDrop and DreamStudio. ( https://dreamstudio.ai/  &  https://clipdrop.co/ )
-#     - StabilityAI's main API is tied to their "DreamStudio" platform
-#     - ClipDrop has a separate website and API. ClipDrop has additional image processing tools and the website is more beginner friendly.
+# --------------------------- API KEY INSTRUCTIONS ---------------------------
+# Paste your Replicate API token below.
+# You can obtain it here: https://replicate.com/account
 #
 
 [Keys]
 
-OpenAI = 
-
-ClipDrop = 
-
-StabilityAI = 
+Replicate =

--- a/assets/settings_default.ini
+++ b/assets/settings_default.ini
@@ -16,21 +16,17 @@ Image_Special_Instructions = The images should be photographic.
 
 [AI Settings]
 
-	# The model used by OpenAI to generate the text.
-	# Default is 'gpt-3.5-turbo' because everyone can access it. If you have access, GPT-4 is recommended. 
-	# See this page for more info about the other models: https://platform.openai.com/docs/quickstart
-Text_Model = gpt-3.5-turbo
+        # The model on Replicate used to generate the text.
+        # Default uses Meta's Llama 3 Instruct model.
+Text_Model = meta/meta-llama-3-70b-instruct
 
 	# Controls the randomness of the AI text generation.
 	# Lowering results in less random completions. Higher temperature results in more random completions.
 	# Default is 1.0.
 Temperature = 1.0
 
-	# The AI image generator service to use.
-	# Possible Values: "openai", "stability", and "clipdrop"
-	# Note: The 'OpenAI' option uses DALLE-2 and does not require a separate additional API Key.
-	#       - However, ClipDrop or StabilityAI is recommended because they are higher quality than DALLE2
-Image_Platform = openai
+        # The image model on Replicate used to generate pictures.
+Image_Model = stability-ai/sdxl
 
 
 #----------------------------------------- Advanced Section -----------------------------------------


### PR DESCRIPTION
## Summary
- use the `replicate` Python package for text and image generation
- drop OpenAI/ClipDrop/Stability code paths and arguments
- update default settings and API instructions for Replicate
- refresh README with new instructions
- update requirements

## Testing
- `python -m py_compile AIMemeGenerator.py`

------
https://chatgpt.com/codex/tasks/task_e_684724ca0be4832a92532f93b3572866